### PR TITLE
Add dataproc subnetwork override option

### DIFF
--- a/cfretl/dataproc.py
+++ b/cfretl/dataproc.py
@@ -214,6 +214,9 @@ class DataprocFacade:
             "cluster_name": self._cluster_name,
             "project_id": self._project_id,
             "config": {
+                "gce_cluster_config": {
+                    "subnetwork_uri": settings.DATAPROC_SUBNETWORK_URI
+                },
                 "master_config": {
                     "num_instances": 1,
                     "machine_type_uri": "n1-standard-1",

--- a/cfretl/settings.py
+++ b/cfretl/settings.py
@@ -32,6 +32,9 @@ GCS_BUCKET_NAME = config("GCS_BUCKET_NAME", "cfr-ml-jobs")
 # The script from cfretl.scripts which will be uploaded into GCS
 DATAPROC_SCRIPT = config("DATAPROC_SCRIPT", "compute_weights.py")
 
+# Override auto subnetwork allocation for custom subnetworks
+DATAPROC_SUBNETWORK_URI = config("DATAPROC_SUBNETWORK_URI", "auto")
+
 # These are names of the RemoteSettings collections in the main bucket
 # None of these should need to be modified.
 CFR_MODEL = config("CFR_MODEL", TEST_PREFIX + "cfr-ml-model")


### PR DESCRIPTION
To resolve `400 Network 'default' requires explicit subnetworks for instance creation. Specify a 'legacy' or 'auto' network, or specify subnetwork explicitly.`

Tested and seems to work.